### PR TITLE
Load py_runtime_pair from rules_python

### DIFF
--- a/python/dist/system_python.bzl
+++ b/python/dist/system_python.bzl
@@ -71,7 +71,7 @@ def fuzzing_py_install_deps():
 _build_file = """
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+load("@rules_python//python:py_runtime_pair.bzl", "py_runtime_pair")
 
 cc_library(
    name = "python_headers",


### PR DESCRIPTION
Bazel 8 requires loading `py_runtime_pair` from `rules_python` since it is deprecated in `bazel_tools`